### PR TITLE
add eq5d domain variables to relevant years of the HSE

### DIFF
--- a/R/read_2003.R
+++ b/R/read_2003.R
@@ -69,19 +69,20 @@ read_2003 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2003/UKDA-5098-tab/tab/hse03ai.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7", "-8", "-9", "-90", "-90.0", "N/A"))
-
+  
   setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , 970:1037])
     smk_vars <- colnames(data[ , 912:969])
     health_vars <- paste0("compm", 1:15)
-
+    eq5d_vars <- colnames(data[, 287:292])
+    
     other_vars <- Hmisc::Cs(
       mintb, addnum,
       area, cluster, int_wt, #child_wt,
@@ -95,34 +96,31 @@ read_2003 <- function(
       educend, topqual3,
       eqv5,
       #eqvinc,
-
+      
       marstatb, # marital status inc cohabitees
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data, c("area", "imd2004", "d7unit", "int_wt", "marstatb", "ethnici", "pserial"),
                        c("psu", "qimd", "d7unitwg", "wt_int", "marstat", "ethnicity_raw", "hse_id"))
-
+  
   data[ , psu := paste0("2003_", psu)]
   data[ , cluster := paste0("2003_", cluster)]
-
+  
   data[ , year := 2003]
   data[ , country := "England"]
-
+  
   data[ , quarter := c(1:4)[findInterval(mintb, c(1, 4, 7, 10))]]
   data[ , mintb := NULL]
-
+  
   return(data[])
 }
-
-
-

--- a/R/read_2006.R
+++ b/R/read_2006.R
@@ -1,4 +1,3 @@
-
 #' Read the Health Survey for England 2006
 #'
 #' Reads and does basic cleaning on the Health Survey for England 2006.
@@ -66,22 +65,23 @@ read_2006 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2006/UKDA-5809-tab/tab/hse06ai.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7","-8",  "-9", "-90", "-90.0", "N/A"))
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , 730:801])
     smk_vars <- colnames(data[ , 1689:1762])
     health_vars <- paste0("compm", 1:15)
-
+    eq5d_vars <- colnames(data[, 931:936])
+    
     other_vars <- Hmisc::Cs(
       mintb, addnum,
       psu, cluster, wt_int, child_wt,
@@ -94,35 +94,31 @@ read_2006 <- function(
       children, infants,
       educend, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatc, # marital status inc cohabitees
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data, c("imd2004", "d7unit", "marstatc", "ethinda", "pserial"),
                        c("qimd", "d7unitwg", "marstat", "ethnicity_raw", "hse_id"))
-
+  
   data[ , psu := paste0("2006_", psu)]
   data[ , cluster := paste0("2006_", cluster)]
-
+  
   data[ , year := 2006]
   data[ , country := "England"]
-
+  
   data[ , quarter := c(1:4)[findInterval(mintb, c(1, 4, 7, 10))]]
   data[ , mintb := NULL]
-
+  
   return(data[])
 }
-
-
-
-

--- a/R/read_2008.R
+++ b/R/read_2008.R
@@ -67,22 +67,23 @@ read_2008 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2008/UKDA-6397-tab/tab/hse08ai.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7", "-8", "-9", "-90", "-90.0", "N/A"))
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , 445:522])
     smk_vars <- colnames(data[ , 1831:1981])
     health_vars <- paste0("compm", 1:15)
-
+    eq5d_vars <- colnames(data[, c(767,776,780,774,635)])
+    
     other_vars <- Hmisc::Cs(
       mintb, addnum,
       psu, cluster, wt_int,
@@ -95,31 +96,31 @@ read_2008 <- function(
       children, infants,
       educend, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatc, # marital status inc cohabitees
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data, c("marstatc", "origin", "pserial"), c("marstat", "ethnicity_raw", "hse_id"))
-
+  
   data[ , psu := paste0("2008_", psu)]
   data[ , cluster := paste0("2008_", cluster)]
-
+  
   data[ , year := 2008]
   data[ , country := "England"]
-
+  
   data[ , quarter := c(1:4)[findInterval(mintb, c(1, 4, 7, 10))]]
   data[ , mintb := NULL]
-
+  
   return(data[])
 }
 

--- a/R/read_2010.R
+++ b/R/read_2010.R
@@ -60,22 +60,23 @@ read_2010 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2010/UKDA-6986-tab/tab/hse10ai.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7", "-8", "-9", "-90", "-90.0", "N/A"))
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , 520:610])
     smk_vars <- colnames(data[ , c(1376:1489, 1501:1523)])
     health_vars <- paste0("compm", 1:15)
-
+    eq5d_vars <- colnames(data[, 956:960])
+    
     other_vars <- Hmisc::Cs(
       mintb, addnum,
       psu, cluster, wt_int,
@@ -89,35 +90,37 @@ read_2010 <- function(
       children, infants,
       educend, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatc, # marital status inc cohabitees
-
+      
       landlord, gor, fathsm, mothsm,
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data, c("imd2007", "marstatc", "origin", "pserial"), c("qimd", "marstat", "ethnicity_raw", "hse_id"))
-
+  
   data[ , psu := paste0("2010_", psu)]
   data[ , cluster := paste0("2010_", cluster)]
-
+  
   data[ , year := 2010]
   data[ , country := "England"]
-
+  
   data[ , quarter := c(1:4)[findInterval(mintb, c(1, 4, 7, 10))]]
   data[ , mintb := NULL]
-
+  
   return(data[])
 }
+
+
 
 
 

--- a/R/read_2011.R
+++ b/R/read_2011.R
@@ -73,22 +73,23 @@ read_2011 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2011/UKDA-7260-tab/tab/hse2011ai.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7","-8",  "-9", "-90", "-90.0", "N/A"))
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , 680:1796])
     smk_vars <- colnames(data[ , 2217:2361])
     health_vars <- paste0("compm", 1:15)
-
+    eq5d_vars <- colnames(data[, 1897:1901])
+    
     other_vars <- Hmisc::Cs(
       mintb, addnum,
       PSU, Cluster, wt_int, wt_drink,
@@ -102,33 +103,33 @@ read_2011 <- function(
       Children, Infants,
       EducEnd, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatc, # marital status inc cohabitees
-
+      
       landlord, gor1, smkdad, smkmum,
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data, c("marstatc", "origin", "pserial", "smkdad", "smkmum", "gor1"), c("marstat", "ethnicity_raw", "hse_id", "fathsm", "mothsm", "gor"))
-
+  
   data[ , psu := paste0("2011_", psu)]
   data[ , cluster := paste0("2011_", cluster)]
-
+  
   data[ , year := 2011]
   data[ , country := "England"]
-
+  
   data[ , quarter := c(1:4)[findInterval(mintb, c(1, 4, 7, 10))]]
   data[ , mintb := NULL]
-
+  
   return(data[])
 }
 

--- a/R/read_2012.R
+++ b/R/read_2012.R
@@ -57,22 +57,23 @@ read_2012 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2012/UKDA-7480-tab/tab/hse2012ai.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7", "-8", "-9", "-90", "-90.0", "N/A"))
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , 502:652])
     smk_vars <- colnames(data[ , 2117:2254])
     health_vars <- paste0("complst", 1:15)
-
+    eq5d_vars <- colnames(data[, 744:748])
+    
     other_vars <- Hmisc::Cs(
       mintb, addnum,
       PSU, Cluster, wt_int, #wt_sc,
@@ -86,37 +87,39 @@ read_2012 <- function(
       Children, Infants,
       EducEnd, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatc, # marital status inc cohabitees
-
+      
       landlord, gor1, smkdad, smkmum,
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data,
                        c("gor1", "marstatc", "smkdad", "smkmum", "origin", "pserial", paste0("complst", 1:15)),
                        c("gor", "marstat", "fathsm", "mothsm", "ethnicity_raw", "hse_id", paste0("compm", 1:15)))
-
+  
   data[ , psu := paste0("2012_", psu)]
   data[ , cluster := paste0("2012_", cluster)]
-
+  
   data[ , year := 2012]
   data[ , country := "England"]
-
+  
   data[ , quarter := c(1:4)[findInterval(mintb, c(1, 4, 7, 10))]]
   data[ , mintb := NULL]
-
+  
   return(data[])
 }
+
+
 
 
 

--- a/R/read_2014.R
+++ b/R/read_2014.R
@@ -65,22 +65,23 @@ read_2014 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2014/UKDA-7919-tab/tab/hse2014ai.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7", "-8", "-9", "-90", "-90.0", "N/A"))
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , 672:831])
     smk_vars <- colnames(data[ , 1714:1957])
     health_vars <- paste0("complst", 1:15)
-
+    eq5d_vars <- colnames(data[, 939:943])
+    
     other_vars <- Hmisc::Cs(
       mintb, addnum,
       psu, cluster, wt_int,
@@ -94,35 +95,36 @@ read_2014 <- function(
       children, infants,
       educEnd, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatd, # marital status inc cohabitees
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data,
                        c("longend2", "marstatd", "age90", "origin3", "pserial", "hrollwk", "hrollwe", paste0("complst", 1:15)),
                        c("longend", "marstat", "age", "ethnicity_raw", "hse_id", "rollwk", "rollwe", paste0("compm", 1:15)))
-
+  
   data[ , psu := paste0("2014_", psu)]
   data[ , cluster := paste0("2014_", cluster)]
-
+  
   data[ , year := 2014]
   data[ , country := "England"]
-
+  
   data[ , quarter := c(1:4)[findInterval(mintb, c(1, 4, 7, 10))]]
   data[ , mintb := NULL]
-
+  
   return(data[])
 }
+
 
 
 

--- a/R/read_2017.R
+++ b/R/read_2017.R
@@ -1,4 +1,3 @@
-
 #' Read the Health Survey for England 2017
 #'
 #' Reads and does basic cleaning on the Health Survey for England 2017.
@@ -38,23 +37,24 @@ read_2017 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2017/UKDA-8488-tab/tab/hse17i_eul_v1.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7", "-8", "-9", "-90", "-90.0", "N/A")
   )
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , c(50, 61, 749:801, 925:969, 1180:1203, 1535:1578)])
     smk_vars <- colnames(data[ , c(19, 20, 44, 55, 62, 727:748, 905:924, 1019:1043, 1204:1332, 1579:1592)])
     health_vars <- paste0("complst", 1:15)
-
+    eq5d_vars <- colnames(data[ , 970:974])
+    
     other_vars <- Hmisc::Cs(
       qrtint, addnum,
       psu, cluster, wt_int, #wt_sc,
@@ -67,32 +67,35 @@ read_2017 <- function(
       #Ag015g4, #Children, Infants,
       educend, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatd, # marital status inc cohabitees
-
+      
       # how much they weigh
       htval, wtval)
-
-    names <- c(other_vars, alc_vars, smk_vars, health_vars)
-
+    
+    names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data,
                        c("qrtint", "marstatd", "origin2", "activb2", "stwork","seriala", paste0("complst", 1:15)),
                        c("quarter", "marstat", "ethnicity_raw", "activb", "paidwk","hse_id", paste0("compm", 1:15)))
-
+  
+  data.table::setnames(data,
+                       c("mobil17", "selfca17", "usuala17", "pain17", "anxiet17"),
+                       c("mobility_5l", "selfcare_5l", "usualact_5l", "pain_5l", "anxiety_5l") )
+  
   data[ , psu := paste0("2017_", psu)]
   data[ , cluster := paste0("2017_", cluster)]
-
+  
   data[ , year := 2017]
   data[ , country := "England"]
-
+  
   return(data[])
 }
-
 
 

--- a/R/read_2018.R
+++ b/R/read_2018.R
@@ -1,4 +1,3 @@
-
 #' Read the Health Survey for England 2018
 #'
 #' Reads and does basic cleaning on the Health Survey for England 2018.
@@ -24,24 +23,24 @@ read_2018 <- function(
     file = "HAR_PR/PR/Consumption_TA/HSE/Health Survey for England (HSE)/HSE 2018/tab/hse_2018_eul_22052020.tab",
     select_cols = c("tobalc", "all")[1]
 ) {
-
+  
   ##################################################################################
   # General population
-
+  
   data <- data.table::fread(
     paste0(root, file),
     na.strings = c("NA", "", "-1", "-2", "-6", "-7", "-8", "-9", "-90", "-90.0", "-99", "N/A"))
-
+  
   data.table::setnames(data, names(data), tolower(names(data)))
-
+  
   if(select_cols == "tobalc") {
-
+    
     alc_vars <- colnames(data[ , c(55:58, 70:73, 805:925, 1097:1141)])
     smk_vars <- colnames(data[ , c(24, 25, 49, 64, 75, 76, 655:804, 1057:1096)])
     health_vars <- paste0("complst", 1:15)
     eq5d_vars <- Hmisc::Cs(Mobil17, SelfCa17, UsualA17, Pain17, Anxiet17,
                            Mobil17g3, SelfCa17g3, UsualA17g3, Pain17g3, Anxiet17g3)
-
+    
     other_vars <- Hmisc::Cs(
       qrtint, #addnum,
       psu_scr, cluster195, wt_int, #wt_sc,
@@ -54,38 +53,36 @@ read_2018 <- function(
       #Ag015g4, #Children, Infants,
       educend, topqual3,
       eqv5, #eqvinc,
-
+      
       marstatd, # marital status inc cohabitees
-
+      
       # how much they weigh
       htval, wtval)
-
+    
     names <- c(other_vars, alc_vars, smk_vars, health_vars, eq5d_vars)
-
+    
     names <- tolower(names)
-
+    
     data <- data[ , names, with = F]
-
+    
   }
-
+  
   data.table::setnames(data,
                        c("cluster195", "psu_scr", "qrtint", "marstatd", "origin2", "activb2", "stwork","seriala", paste0("complst", 1:15)),
                        c("cluster", "psu", "quarter", "marstat", "ethnicity_raw", "activb", "paidwk","hse_id", paste0("compm", 1:15)))
-
+  
   data.table::setnames(data,
                        c("mobil17", "selfca17", "usuala17", "pain17", "anxiet17",
                          "mobil17g3", "selfca17g3", "usuala17g3", "pain17g3", "anxiet17g3"),
-                       c("MO_5l", "SC_5l", "UA_5l", "PA_5l", "AD_5l",
-                         "MO_3l", "SC_3l", "UA_3l", "PA_3l", "AD_3l") )
-
+                       c("mobility_5l", "selfcare_5l", "usualact_5l", "pain_5l", "anxiety_5l",
+                         "mobility", "selfcare", "usualact", "pain", "anxiety") )
+  
   data[ , psu := paste0("2018_", psu)]
   data[ , cluster := paste0("2018_", cluster)]
-
+  
   data[ , year := 2018]
   data[ , country := "England"]
-
+  
   return(data[])
 }
-
-
 


### PR DESCRIPTION
Added EQ-5D to the HSE reading functions 

- EQ-5D-3L: 2003, 2006, 2008, 2010, 2011, 2012, 2014, 2018
- EQ-5D-5L: 2017, 2018

Note both versions in 2018